### PR TITLE
UI: Improve Spacing Between Pagination and Footer on Artisans Page (#11)

### DIFF
--- a/css/artisans.css
+++ b/css/artisans.css
@@ -3,7 +3,9 @@
     background-color: #f8fafc;
     color: var(--text-color);
     line-height: 1.6;
-    padding-bottom: 4rem;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Hero Section */
@@ -170,8 +172,9 @@
 
 /* Artisans Grid */
 .artisans-grid {
-    padding: 4rem 0;
+    padding: 4rem 0 0;
     background-color: #f8fafc;
+    flex: 1;
 }
 
 .artisans-container {
@@ -608,7 +611,7 @@
     justify-content: center;
     align-items: center;
     gap: 15px;
-    margin-top: 40px;
+    margin: 40px 0 60px;
 }
 
 .btn-prev,


### PR DESCRIPTION
## This PR addresses the cramped layout at the bottom of the Artisans page by adding proper spacing between the pagination controls and footer.

### Changes Made:
➔ Added 60px bottom margin to the pagination container
➔ Maintained existing top margin for consistency
➔ Ensured responsive behavior across all screen sizes
### Before:
➔ Pagination controls were too close to the footer
➔ Layout appeared cramped and unbalanced
### After:
➔ 60px space added between pagination and footer
➔ Improved visual hierarchy
➔ More professional and polished appearance
### Testing:
➔ Verified on desktop and laptop screens
➔ Checked website responsiveness
➔ Confirmed no layout issues were introduced
### Screenshots:
### Before:
![image](https://github.com/user-attachments/assets/278c774b-7e72-4af7-8036-65362465b863)
### After:
![image](https://github.com/user-attachments/assets/73928a43-cb70-40e0-94d3-ae136f50a0ca)

Closes #11 